### PR TITLE
Add SQLite integration for persistence layer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.xerial:sqlite-jdbc:3.50.3.0")
+    implementation("org.hibernate.orm:hibernate-community-dialects:6.6.26.Final")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:sqlite:eventshuffle.db
+    driver-class-name: org.sqlite.JDBC
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.community.dialect.SQLiteDialect


### PR DESCRIPTION
- Added SQLite JDBC and Hibernate community dialect dependencies to build.gradle.kts
- Configured Spring Boot datasource and JPA settings in application.yml
- Enabled automatic schema updates with Hibernate (ddl-auto: update)
- Database file now stored locally as eventshuffle.db